### PR TITLE
Update email focus state to match LinkedIn and Twitter

### DIFF
--- a/app/components/copy.tsx
+++ b/app/components/copy.tsx
@@ -37,7 +37,7 @@ export default function Copy({ children, text, type }: TooltipProps) {
       <RadixTooltip.Root open={copied}>
         <RadixTooltip.Trigger
           onClick={() => copyToClipboard(text)}
-          className="text-start"
+          className="text-start rounded-xl p-2 -m-2"
         >
           {children}
         </RadixTooltip.Trigger>


### PR DESCRIPTION
## Summary
Updated the email button's focus ring to match the larger, more rounded appearance of the LinkedIn and Twitter buttons by adding rounded corners and padding to the RadixTooltip.Trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)