### PR TITLE
Add agents.md with Base UI preference rule

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,7 @@
+# Claude Code Rules
+
+## UI Component Guidelines
+
+- Always use Base UI for new components instead of Radix UI unless there's a specific reason not to (e.g., existing component already uses Radix, or Base UI doesn't support a required feature)
+- When building new UI primitives, prefer Base UI's unstyled components
+- Document the reason if Radix UI must be used for a specific component


### PR DESCRIPTION
Establishes a guideline to prefer Base UI over Radix UI for new components unless there's a specific reason not to.

This helps maintain consistency in component library choices and ensures we're using the most appropriate primitives for our UI needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)