### PR TITLE
Make Sonner toasts pill-shaped

### DIFF
--- a/app/components/ui/sonner.tsx
+++ b/app/components/ui/sonner.tsx
@@ -15,7 +15,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast !rounded-2xl px-6 group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",

--- a/app/globals.css
+++ b/app/globals.css
@@ -189,3 +189,11 @@ body {
 @utility text-balance {
   text-wrap: balance;
 }
+
+/* Override Sonner toast border radius */
+[data-sonner-toast][data-styled="true"] {
+  border-radius: 28px !important;
+  padding-left: 20px !important;
+  padding-right: 20px !important;
+}
+


### PR DESCRIPTION
Makes toast notifications pill-shaped with rounded-2xl styling and optimized horizontal padding for improved visual design.

The toast displays as a perfect pill when single-line and maintains balanced proportions for multi-line messages.

🤖 Generated with Claude Code