### PR TITLE
Prevent hover animations on touch devices with semantic tokens

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Heading, Text } from "./components/text";
 import Link from "next/link";
 import Image from "next/image";
@@ -33,6 +33,14 @@ const reducedMotionVariants = {
   exit: { opacity: 0 },
 };
 
+function useCanHover() {
+  const [canHover, setCanHover] = useState(false);
+  useEffect(() => {
+    setCanHover(window.matchMedia("(hover: hover)").matches);
+  }, []);
+  return canHover;
+}
+
 interface CTACardContentProps {
   isActive: boolean;
   icon: React.ReactNode;
@@ -57,7 +65,7 @@ function CTACardContent({
 
   return (
     <>
-      <span className="w-10 h-10 sm:w-12 sm:h-12 shrink-0 flex items-center justify-center rounded-full bg-black/10 sm:mb-auto relative">
+      <span className="w-10 h-10 sm:w-12 sm:h-12 shrink-0 flex items-center justify-center rounded-full bg-overlay-light sm:mb-auto relative">
         <AnimatePresence mode="popLayout" initial={false}>
           {isActive ? (
             <motion.span
@@ -134,15 +142,16 @@ interface CTACardProps {
 
 function CTACard({ href, icon, title, subtitle, hoverSubtitle }: CTACardProps) {
   const [isActive, setIsActive] = useState(false);
+  const canHover = useCanHover();
 
   return (
     <Link
       href={href}
-      className="flex flex-row sm:flex-col items-center sm:items-start gap-4 sm:gap-0 sm:justify-between p-4 sm:p-6 rounded-2xl sm:rounded-3xl border-[0.5px] border-black/20 flex-1 min-w-0 hover:bg-black/5 transition-colors"
-      onMouseEnter={() => setIsActive(true)}
-      onMouseLeave={() => setIsActive(false)}
-      onFocus={() => setIsActive(true)}
-      onBlur={() => setIsActive(false)}
+      className="flex flex-row sm:flex-col items-center sm:items-start gap-4 sm:gap-0 sm:justify-between p-4 sm:p-6 rounded-2xl sm:rounded-3xl border-[0.5px] border-border-medium flex-1 min-w-0 hover:bg-overlay-subtle transition-colors"
+      onMouseEnter={() => canHover && setIsActive(true)}
+      onMouseLeave={() => canHover && setIsActive(false)}
+      onFocus={() => canHover && setIsActive(true)}
+      onBlur={() => canHover && setIsActive(false)}
     >
       <CTACardContent
         isActive={isActive}
@@ -166,18 +175,19 @@ interface CopyCTACardProps {
 
 function CopyCTACard({ text, icon, title, subtitle, hoverSubtitle }: CopyCTACardProps) {
   const [isActive, setIsActive] = useState(false);
+  const canHover = useCanHover();
 
   return (
     <Copy
       text={text}
       type="Email"
-      onFocus={() => setIsActive(true)}
-      onBlur={() => setIsActive(false)}
+      onFocus={() => canHover && setIsActive(true)}
+      onBlur={() => canHover && setIsActive(false)}
     >
       <div
-        className="flex flex-row sm:flex-col items-center sm:items-start gap-4 sm:gap-0 sm:justify-between p-4 sm:p-6 rounded-2xl sm:rounded-3xl border-[0.5px] border-black/20 flex-1 min-w-0 hover:bg-black/5 transition-colors h-full cursor-pointer"
-        onMouseEnter={() => setIsActive(true)}
-        onMouseLeave={() => setIsActive(false)}
+        className="flex flex-row sm:flex-col items-center sm:items-start gap-4 sm:gap-0 sm:justify-between p-4 sm:p-6 rounded-2xl sm:rounded-3xl border-[0.5px] border-border-medium flex-1 min-w-0 hover:bg-overlay-subtle transition-colors h-full cursor-pointer"
+        onMouseEnter={() => canHover && setIsActive(true)}
+        onMouseLeave={() => canHover && setIsActive(false)}
       >
         <CTACardContent
           isActive={isActive}


### PR DESCRIPTION
Add useCanHover() hook to detect devices with hover support and gate hover/focus animations only for non-touch devices. Replace hardcoded color values with semantic tokens for better maintainability and design consistency.

Changes include:
- useCanHover() hook using media query detection
- Semantic color tokens (border-border-medium, bg-overlay-light, bg-overlay-subtle) replacing hardcoded values
- Touch device awareness for animation triggers