### PR TITLE
Add paper texture background across the site

### DIFF
--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -3,25 +3,31 @@ export function PaperTexture() {
     <>
       {/* Coarse paper grain */}
       <svg
-        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.07] sm:opacity-[0.04] dark:opacity-[0.06] dark:sm:opacity-[0.035]"
+        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.12] sm:opacity-[0.07] dark:opacity-[0.10] dark:sm:opacity-[0.06]"
         aria-hidden="true"
       >
-        <filter id="paper-grain">
+        <filter id="paper-grain" colorInterpolationFilters="sRGB">
           <feTurbulence
             type="fractalNoise"
             baseFrequency="0.04"
             numOctaves="5"
             stitchTiles="stitch"
           />
+          <feColorMatrix type="saturate" values="0" />
+          <feComponentTransfer>
+            <feFuncR type="linear" slope="1.12" />
+            <feFuncG type="linear" slope="1.04" />
+            <feFuncB type="linear" slope="0.88" />
+          </feComponentTransfer>
         </filter>
         <rect width="100%" height="100%" filter="url(#paper-grain)" />
       </svg>
       {/* Fine noise */}
       <svg
-        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.08] sm:opacity-[0.05] dark:opacity-[0.07] dark:sm:opacity-[0.04]"
+        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.10] sm:opacity-[0.06] dark:opacity-[0.08] dark:sm:opacity-[0.05]"
         aria-hidden="true"
       >
-        <filter id="paper-noise">
+        <filter id="paper-noise" colorInterpolationFilters="sRGB">
           <feTurbulence
             type="turbulence"
             baseFrequency="0.5"
@@ -29,6 +35,11 @@ export function PaperTexture() {
             stitchTiles="stitch"
           />
           <feColorMatrix type="saturate" values="0" />
+          <feComponentTransfer>
+            <feFuncR type="linear" slope="1.12" />
+            <feFuncG type="linear" slope="1.04" />
+            <feFuncB type="linear" slope="0.88" />
+          </feComponentTransfer>
         </filter>
         <rect width="100%" height="100%" filter="url(#paper-noise)" />
       </svg>

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -1,7 +1,7 @@
 export function PaperTexture() {
   return (
     <svg
-      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.07] sm:opacity-[0.04] dark:opacity-[0.06] dark:sm:opacity-[0.035]"
+      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.12] sm:opacity-[0.05] dark:opacity-[0.10] dark:sm:opacity-[0.04]"
       aria-hidden="true"
     >
       <filter id="paper-texture">

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -1,0 +1,18 @@
+export function PaperTexture() {
+  return (
+    <svg
+      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.035] dark:opacity-[0.03]"
+      aria-hidden="true"
+    >
+      <filter id="paper-texture">
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="0.04"
+          numOctaves="5"
+          stitchTiles="stitch"
+        />
+      </filter>
+      <rect width="100%" height="100%" filter="url(#paper-texture)" />
+    </svg>
+  );
+}

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -1,7 +1,7 @@
 export function PaperTexture() {
   return (
     <svg
-      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.035] dark:opacity-[0.03]"
+      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.07] sm:opacity-[0.04] dark:opacity-[0.06] dark:sm:opacity-[0.035]"
       aria-hidden="true"
     >
       <filter id="paper-texture">

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -3,7 +3,7 @@ export function PaperTexture() {
     <>
       {/* Coarse paper grain */}
       <svg
-        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.12] sm:opacity-[0.07] dark:opacity-[0.10] dark:sm:opacity-[0.06]"
+        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.06] sm:opacity-[0.04] dark:opacity-[0.05] dark:sm:opacity-[0.035]"
         aria-hidden="true"
       >
         <filter id="paper-grain" colorInterpolationFilters="sRGB">
@@ -24,7 +24,7 @@ export function PaperTexture() {
       </svg>
       {/* Fine noise */}
       <svg
-        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.10] sm:opacity-[0.06] dark:opacity-[0.08] dark:sm:opacity-[0.05]"
+        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.05] sm:opacity-[0.035] dark:opacity-[0.04] dark:sm:opacity-[0.03]"
         aria-hidden="true"
       >
         <filter id="paper-noise" colorInterpolationFilters="sRGB">

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -3,7 +3,7 @@ export function PaperTexture() {
     <>
       {/* Coarse paper grain */}
       <svg
-        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.06] sm:opacity-[0.04] dark:opacity-[0.05] dark:sm:opacity-[0.035]"
+        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.06] sm:opacity-[0.025] dark:opacity-[0.05] dark:sm:opacity-[0.02]"
         aria-hidden="true"
       >
         <filter id="paper-grain" colorInterpolationFilters="sRGB">
@@ -24,7 +24,7 @@ export function PaperTexture() {
       </svg>
       {/* Fine noise */}
       <svg
-        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.05] sm:opacity-[0.035] dark:opacity-[0.04] dark:sm:opacity-[0.03]"
+        className="pointer-events-none absolute inset-0 z-0 h-full w-full opacity-[0.05] sm:opacity-[0.02] dark:opacity-[0.04] dark:sm:opacity-[0.015]"
         aria-hidden="true"
       >
         <filter id="paper-noise" colorInterpolationFilters="sRGB">

--- a/app/components/paper-texture.tsx
+++ b/app/components/paper-texture.tsx
@@ -1,18 +1,37 @@
 export function PaperTexture() {
   return (
-    <svg
-      className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.12] sm:opacity-[0.05] dark:opacity-[0.10] dark:sm:opacity-[0.04]"
-      aria-hidden="true"
-    >
-      <filter id="paper-texture">
-        <feTurbulence
-          type="fractalNoise"
-          baseFrequency="0.04"
-          numOctaves="5"
-          stitchTiles="stitch"
-        />
-      </filter>
-      <rect width="100%" height="100%" filter="url(#paper-texture)" />
-    </svg>
+    <>
+      {/* Coarse paper grain */}
+      <svg
+        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.07] sm:opacity-[0.04] dark:opacity-[0.06] dark:sm:opacity-[0.035]"
+        aria-hidden="true"
+      >
+        <filter id="paper-grain">
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.04"
+            numOctaves="5"
+            stitchTiles="stitch"
+          />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#paper-grain)" />
+      </svg>
+      {/* Fine noise */}
+      <svg
+        className="pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.08] sm:opacity-[0.05] dark:opacity-[0.07] dark:sm:opacity-[0.04]"
+        aria-hidden="true"
+      >
+        <filter id="paper-noise">
+          <feTurbulence
+            type="turbulence"
+            baseFrequency="0.5"
+            numOctaves="2"
+            stitchTiles="stitch"
+          />
+          <feColorMatrix type="saturate" values="0" />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#paper-noise)" />
+      </svg>
+    </>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,137 +104,137 @@
 }
 
 :root {
-  /* shadcn/ui base variables - neutral theme (adjusted to match neutral palette) */
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.147 0.004 49.3);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.147 0.004 49.3);
-  --primary: oklch(0.214 0.009 43.1);
-  --primary-foreground: oklch(0.986 0.002 67.8);
-  --secondary: oklch(0.96 0.002 17.2);
-  --secondary-foreground: oklch(0.214 0.009 43.1);
-  --muted: oklch(0.96 0.002 17.2);
-  --muted-foreground: oklch(0.547 0.021 43.1);
-  --accent: oklch(0.96 0.002 17.2);
-  --accent-foreground: oklch(0.214 0.009 43.1);
+  /* shadcn/ui base variables - warm neutral palette */
+  --card: oklch(0.993 0.006 80);
+  --card-foreground: oklch(0.147 0.007 65);
+  --popover: oklch(0.993 0.006 80);
+  --popover-foreground: oklch(0.147 0.007 65);
+  --primary: oklch(0.216 0.012 65);
+  --primary-foreground: oklch(0.985 0.008 80);
+  --secondary: oklch(0.955 0.008 75);
+  --secondary-foreground: oklch(0.216 0.012 65);
+  --muted: oklch(0.955 0.008 75);
+  --muted-foreground: oklch(0.540 0.022 65);
+  --accent: oklch(0.955 0.008 75);
+  --accent-foreground: oklch(0.216 0.012 65);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0.005 34.3);
-  --input: oklch(0.922 0.005 34.3);
-  --ring: oklch(0.714 0.014 41.2);
+  --border: oklch(0.918 0.010 75);
+  --input: oklch(0.918 0.010 75);
+  --ring: oklch(0.710 0.018 65);
   --radius: 0.45rem;
   --chart-1: oklch(0.845 0.143 164.978);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.596 0.145 163.225);
   --chart-4: oklch(0.508 0.118 165.612);
   --chart-5: oklch(0.432 0.095 166.913);
-  --sidebar: oklch(0.986 0.002 67.8);
-  --sidebar-foreground: oklch(0.147 0.004 49.3);
-  --sidebar-primary: oklch(0.214 0.009 43.1);
-  --sidebar-primary-foreground: oklch(0.986 0.002 67.8);
-  --sidebar-accent: oklch(0.96 0.002 17.2);
-  --sidebar-accent-foreground: oklch(0.214 0.009 43.1);
-  --sidebar-border: oklch(0.922 0.005 34.3);
-  --sidebar-ring: oklch(0.714 0.014 41.2);
+  --sidebar: oklch(0.980 0.008 80);
+  --sidebar-foreground: oklch(0.147 0.007 65);
+  --sidebar-primary: oklch(0.216 0.012 65);
+  --sidebar-primary-foreground: oklch(0.985 0.008 80);
+  --sidebar-accent: oklch(0.955 0.008 75);
+  --sidebar-accent-foreground: oklch(0.216 0.012 65);
+  --sidebar-border: oklch(0.918 0.010 75);
+  --sidebar-ring: oklch(0.710 0.018 65);
 
   /* Custom semantic colors - text */
-  --text-secondary: oklch(0.439 0 0);
-  --text-tertiary: oklch(0.556 0 0);
+  --text-secondary: oklch(0.439 0.006 65);
+  --text-tertiary: oklch(0.556 0.006 65);
 
-  /* Overlay backgrounds (neutral-900 with opacity) */
-  --overlay-subtle: oklch(0.205 0 0 / 0.05);
-  --overlay-light: oklch(0.205 0 0 / 0.1);
-  --overlay-medium: oklch(0.205 0 0 / 0.15);
-  --overlay-strong: oklch(0.205 0 0 / 0.2);
-  --overlay-white: oklch(1 0 0 / 0.2);
+  /* Overlay backgrounds (warm neutral with opacity) */
+  --overlay-subtle: oklch(0.205 0.006 65 / 0.05);
+  --overlay-light: oklch(0.205 0.006 65 / 0.1);
+  --overlay-medium: oklch(0.205 0.006 65 / 0.15);
+  --overlay-strong: oklch(0.205 0.006 65 / 0.2);
+  --overlay-white: oklch(0.985 0.008 80 / 0.2);
 
   /* Borders with opacity */
-  --border-hairline: oklch(0.869 0 0 / 0.005);
-  --border-subtle: oklch(0.205 0 0 / 0.05);
-  --border-light: oklch(0.205 0 0 / 0.1);
-  --border-medium: oklch(0.205 0 0 / 0.2);
-  --border-strong: oklch(0.205 0 0 / 0.3);
+  --border-hairline: oklch(0.869 0.006 75 / 0.005);
+  --border-subtle: oklch(0.205 0.006 65 / 0.05);
+  --border-light: oklch(0.205 0.006 65 / 0.1);
+  --border-medium: oklch(0.205 0.006 65 / 0.2);
+  --border-strong: oklch(0.205 0.006 65 / 0.3);
 
   /* Status colors */
   --success: oklch(0.627 0.178 149.2);
   --success-foreground: oklch(1 0 0);
 
   /* Skeleton loading */
-  --skeleton: oklch(0.205 0 0 / 0.15);
+  --skeleton: oklch(0.205 0.006 65 / 0.15);
 
   /* Elevated surfaces */
-  --surface-elevated: oklch(1 0 0);
+  --surface-elevated: oklch(0.993 0.006 80);
 
   /* Badge background */
-  --badge-bg: oklch(0.869 0 0);
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.147 0.004 49.3);
+  --badge-bg: oklch(0.869 0.008 75);
+  --background: oklch(0.985 0.008 80);
+  --foreground: oklch(0.147 0.007 65);
 }
 
 .dark {
-  --background: oklch(0.147 0.004 49.3);
-  --foreground: oklch(0.986 0.002 67.8);
-  --card: oklch(0.214 0.009 43.1);
-  --card-foreground: oklch(0.986 0.002 67.8);
-  --popover: oklch(0.214 0.009 43.1);
-  --popover-foreground: oklch(0.986 0.002 67.8);
-  --primary: oklch(0.922 0.005 34.3);
-  --primary-foreground: oklch(0.214 0.009 43.1);
-  --secondary: oklch(0.268 0.011 36.5);
-  --secondary-foreground: oklch(0.986 0.002 67.8);
-  --muted: oklch(0.268 0.011 36.5);
-  --muted-foreground: oklch(0.714 0.014 41.2);
-  --accent: oklch(0.268 0.011 36.5);
-  --accent-foreground: oklch(0.986 0.002 67.8);
+  --background: oklch(0.150 0.008 65);
+  --foreground: oklch(0.930 0.010 80);
+  --card: oklch(0.210 0.012 65);
+  --card-foreground: oklch(0.930 0.010 80);
+  --popover: oklch(0.210 0.012 65);
+  --popover-foreground: oklch(0.930 0.010 80);
+  --primary: oklch(0.918 0.010 75);
+  --primary-foreground: oklch(0.210 0.012 65);
+  --secondary: oklch(0.265 0.014 65);
+  --secondary-foreground: oklch(0.930 0.010 80);
+  --muted: oklch(0.265 0.014 65);
+  --muted-foreground: oklch(0.710 0.018 65);
+  --accent: oklch(0.265 0.014 65);
+  --accent-foreground: oklch(0.930 0.010 80);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.547 0.021 43.1);
+  --border: oklch(0.985 0.008 80 / 10%);
+  --input: oklch(0.985 0.008 80 / 15%);
+  --ring: oklch(0.540 0.022 65);
   --chart-1: oklch(0.845 0.143 164.978);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.596 0.145 163.225);
   --chart-4: oklch(0.508 0.118 165.612);
   --chart-5: oklch(0.432 0.095 166.913);
-  --sidebar: oklch(0.214 0.009 43.1);
-  --sidebar-foreground: oklch(0.986 0.002 67.8);
+  --sidebar: oklch(0.210 0.012 65);
+  --sidebar-foreground: oklch(0.930 0.010 80);
   --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.986 0.002 67.8);
-  --sidebar-accent: oklch(0.268 0.011 36.5);
-  --sidebar-accent-foreground: oklch(0.986 0.002 67.8);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.547 0.021 43.1);
+  --sidebar-primary-foreground: oklch(0.930 0.010 80);
+  --sidebar-accent: oklch(0.265 0.014 65);
+  --sidebar-accent-foreground: oklch(0.930 0.010 80);
+  --sidebar-border: oklch(0.985 0.008 80 / 10%);
+  --sidebar-ring: oklch(0.540 0.022 65);
 
   /* Custom semantic colors - text */
-  --text-secondary: oklch(0.708 0 0);
-  --text-tertiary: oklch(0.556 0 0);
+  --text-secondary: oklch(0.708 0.008 75);
+  --text-tertiary: oklch(0.556 0.006 70);
 
-  /* Overlay backgrounds (white with opacity) */
-  --overlay-subtle: oklch(1 0 0 / 0.05);
-  --overlay-light: oklch(1 0 0 / 0.1);
-  --overlay-medium: oklch(1 0 0 / 0.15);
-  --overlay-strong: oklch(1 0 0 / 0.2);
-  --overlay-white: oklch(1 0 0 / 0.2);
+  /* Overlay backgrounds (warm white with opacity) */
+  --overlay-subtle: oklch(0.985 0.008 80 / 0.05);
+  --overlay-light: oklch(0.985 0.008 80 / 0.1);
+  --overlay-medium: oklch(0.985 0.008 80 / 0.15);
+  --overlay-strong: oklch(0.985 0.008 80 / 0.2);
+  --overlay-white: oklch(0.985 0.008 80 / 0.2);
 
   /* Borders with opacity */
-  --border-hairline: oklch(1 0 0 / 0.005);
-  --border-subtle: oklch(1 0 0 / 0.05);
-  --border-light: oklch(1 0 0 / 0.1);
-  --border-medium: oklch(1 0 0 / 0.2);
-  --border-strong: oklch(1 0 0 / 0.3);
+  --border-hairline: oklch(0.985 0.008 80 / 0.005);
+  --border-subtle: oklch(0.985 0.008 80 / 0.05);
+  --border-light: oklch(0.985 0.008 80 / 0.1);
+  --border-medium: oklch(0.985 0.008 80 / 0.2);
+  --border-strong: oklch(0.985 0.008 80 / 0.3);
 
   /* Status colors */
   --success: oklch(0.627 0.178 149.2);
-  --success-foreground: oklch(0.205 0 0);
+  --success-foreground: oklch(0.205 0.006 65);
 
   /* Skeleton loading */
-  --skeleton: oklch(1 0 0 / 0.15);
+  --skeleton: oklch(0.985 0.008 80 / 0.15);
 
   /* Elevated surfaces */
-  --surface-elevated: oklch(0.269 0 0);
+  --surface-elevated: oklch(0.269 0.010 70);
 
   /* Badge background */
-  --badge-bg: oklch(0.439 0 0);
+  --badge-bg: oklch(0.439 0.008 70);
 }
 
 /*
@@ -244,69 +244,69 @@
  */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
-    --background: oklch(0.147 0.004 49.3);
-    --foreground: oklch(0.986 0.002 67.8);
-    --card: oklch(0.214 0.009 43.1);
-    --card-foreground: oklch(0.986 0.002 67.8);
-    --popover: oklch(0.214 0.009 43.1);
-    --popover-foreground: oklch(0.986 0.002 67.8);
-    --primary: oklch(0.922 0.005 34.3);
-    --primary-foreground: oklch(0.214 0.009 43.1);
-    --secondary: oklch(0.268 0.011 36.5);
-    --secondary-foreground: oklch(0.986 0.002 67.8);
-    --muted: oklch(0.268 0.011 36.5);
-    --muted-foreground: oklch(0.714 0.014 41.2);
-    --accent: oklch(0.268 0.011 36.5);
-    --accent-foreground: oklch(0.986 0.002 67.8);
+    --background: oklch(0.150 0.008 65);
+    --foreground: oklch(0.930 0.010 80);
+    --card: oklch(0.210 0.012 65);
+    --card-foreground: oklch(0.930 0.010 80);
+    --popover: oklch(0.210 0.012 65);
+    --popover-foreground: oklch(0.930 0.010 80);
+    --primary: oklch(0.918 0.010 75);
+    --primary-foreground: oklch(0.210 0.012 65);
+    --secondary: oklch(0.265 0.014 65);
+    --secondary-foreground: oklch(0.930 0.010 80);
+    --muted: oklch(0.265 0.014 65);
+    --muted-foreground: oklch(0.710 0.018 65);
+    --accent: oklch(0.265 0.014 65);
+    --accent-foreground: oklch(0.930 0.010 80);
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.985 0 0);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.547 0.021 43.1);
+    --border: oklch(0.985 0.008 80 / 10%);
+    --input: oklch(0.985 0.008 80 / 15%);
+    --ring: oklch(0.540 0.022 65);
     --chart-1: oklch(0.845 0.143 164.978);
     --chart-2: oklch(0.696 0.17 162.48);
     --chart-3: oklch(0.596 0.145 163.225);
     --chart-4: oklch(0.508 0.118 165.612);
     --chart-5: oklch(0.432 0.095 166.913);
-    --sidebar: oklch(0.214 0.009 43.1);
-    --sidebar-foreground: oklch(0.986 0.002 67.8);
+    --sidebar: oklch(0.210 0.012 65);
+    --sidebar-foreground: oklch(0.930 0.010 80);
     --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.986 0.002 67.8);
-    --sidebar-accent: oklch(0.268 0.011 36.5);
-    --sidebar-accent-foreground: oklch(0.986 0.002 67.8);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.547 0.021 43.1);
+    --sidebar-primary-foreground: oklch(0.930 0.010 80);
+    --sidebar-accent: oklch(0.265 0.014 65);
+    --sidebar-accent-foreground: oklch(0.930 0.010 80);
+    --sidebar-border: oklch(0.985 0.008 80 / 10%);
+    --sidebar-ring: oklch(0.540 0.022 65);
 
     /* Custom semantic colors - text */
-    --text-secondary: oklch(0.708 0 0);
-    --text-tertiary: oklch(0.556 0 0);
+    --text-secondary: oklch(0.708 0.008 75);
+    --text-tertiary: oklch(0.556 0.006 70);
 
-    /* Overlay backgrounds (white with opacity) */
-    --overlay-subtle: oklch(1 0 0 / 0.05);
-    --overlay-light: oklch(1 0 0 / 0.1);
-    --overlay-medium: oklch(1 0 0 / 0.15);
-    --overlay-strong: oklch(1 0 0 / 0.2);
-    --overlay-white: oklch(1 0 0 / 0.2);
+    /* Overlay backgrounds (warm white with opacity) */
+    --overlay-subtle: oklch(0.985 0.008 80 / 0.05);
+    --overlay-light: oklch(0.985 0.008 80 / 0.1);
+    --overlay-medium: oklch(0.985 0.008 80 / 0.15);
+    --overlay-strong: oklch(0.985 0.008 80 / 0.2);
+    --overlay-white: oklch(0.985 0.008 80 / 0.2);
 
     /* Borders with opacity */
-    --border-hairline: oklch(1 0 0 / 0.005);
-    --border-subtle: oklch(1 0 0 / 0.05);
-    --border-light: oklch(1 0 0 / 0.1);
-    --border-medium: oklch(1 0 0 / 0.2);
-    --border-strong: oklch(1 0 0 / 0.3);
+    --border-hairline: oklch(0.985 0.008 80 / 0.005);
+    --border-subtle: oklch(0.985 0.008 80 / 0.05);
+    --border-light: oklch(0.985 0.008 80 / 0.1);
+    --border-medium: oklch(0.985 0.008 80 / 0.2);
+    --border-strong: oklch(0.985 0.008 80 / 0.3);
 
     /* Status colors */
     --success: oklch(0.627 0.178 149.2);
-    --success-foreground: oklch(0.205 0 0);
+    --success-foreground: oklch(0.205 0.006 65);
 
     /* Skeleton loading */
-    --skeleton: oklch(1 0 0 / 0.15);
+    --skeleton: oklch(0.985 0.008 80 / 0.15);
 
     /* Elevated surfaces */
-    --surface-elevated: oklch(0.269 0 0);
+    --surface-elevated: oklch(0.269 0.010 70);
 
     /* Badge background */
-    --badge-bg: oklch(0.439 0 0);
+    --badge-bg: oklch(0.439 0.008 70);
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
     <html lang="en" className={cn(lora.variable, merriweatherHeading.variable, "font-serif")}>
       <body
         className={cn(
-          "flex flex-col items-center min-h-[100vh] text-sm transition-colors duration-300 text-text-secondary bg-background"
+          "relative flex flex-col items-center min-h-[100vh] text-sm transition-colors duration-300 text-text-secondary bg-background"
         )}
       >
         <PaperTexture />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { cn } from "./utils/cn";
 import { Toaster } from "@/app/components/ui/sonner";
 import { AgentationProvider } from "./components/agentationProvider";
+import { PaperTexture } from "./components/paper-texture";
 
 const lora = Lora({
   subsets: ["latin"],
@@ -58,6 +59,7 @@ export default function RootLayout({
           "flex flex-col items-center min-h-[100vh] text-sm transition-colors duration-300 text-text-secondary bg-background"
         )}
       >
+        <PaperTexture />
         <Header />
         <main className="flex flex-col grow h-full mt-14 container max-w-screen-sm px-6 pt-8 sm:pt-[72px] pb-16 sm:pb-32">
           {children}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a subtle paper/grain texture as the background across the entire site and warms up the color palette for a cohesive, organic feel.

## Changes

### Paper texture background
- **New component:** `app/components/paper-texture.tsx` — renders two SVG layers as a fixed full-viewport overlay:
  - **Coarse paper grain** — `feTurbulence` fractal noise at `baseFrequency="0.04"` for natural paper fiber texture
  - **Fine noise** — `turbulence` at `baseFrequency="0.5"` (desaturated) for a gritty film-grain speckle
- `pointer-events-none` and `aria-hidden="true"` ensure no interaction or accessibility interference
- Responsive opacity: stronger on mobile, subtler on desktop, adjusted per light/dark mode

### Warmer color palette
- Shifted all neutral hues from cool gray (oklch hue 0-49) to warm amber (hue 65-80)
- Added subtle chroma (0.006-0.014) to previously achromatic grays
- **Light mode:** cream-tinted background, cards, and surfaces instead of pure white
- **Dark mode:** warm dark tones instead of cool neutrals
- Text, overlays, borders, skeleton, badge, and surface colors all carry warm undertones
- All three theme sections updated consistently (`:root`, `.dark`, `@media prefers-color-scheme: dark`)

## Technical notes
- Zero external assets — texture is generated purely via SVG filters
- No new dependencies
- All changes are CSS-only (globals.css) plus one new React component
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7e54ae5-994e-474c-911d-3248134a75a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7e54ae5-994e-474c-911d-3248134a75a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

