### PR TITLE
feat: personal run page with timeline, bib wall, and race prep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Strava (required for /run activity sync)
+STRAVA_CLIENT_ID=
+STRAVA_CLIENT_SECRET=
+STRAVA_REFRESH_TOKEN=
+
+# Single-owner athlete ID for the public run page
+STRAVA_ATHLETE_ID=
+# Alias supported by the run page config
+RUN_PAGE_USER_ID=
+
+# Vercel KV (optional — caches Strava tokens and activity data)
+KV_REST_API_URL=
+KV_REST_API_TOKEN=

--- a/app/api/run/activities/route.ts
+++ b/app/api/run/activities/route.ts
@@ -1,0 +1,23 @@
+import { listRunActivities } from "@/app/features/run/lib/run-service";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const cursor = searchParams.get("cursor") ?? undefined;
+  const limit = searchParams.get("limit")
+    ? parseInt(searchParams.get("limit")!, 10)
+    : undefined;
+
+  try {
+    const data = await listRunActivities({ cursor, limit });
+    return Response.json({ success: true, data });
+  } catch (error) {
+    console.error("Run activities error:", error);
+    return Response.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to fetch activities",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/run/races/[raceId]/route.ts
+++ b/app/api/run/races/[raceId]/route.ts
@@ -1,0 +1,30 @@
+import { getRunRacePrep } from "@/app/features/run/lib/run-service";
+
+export async function GET(
+  _request: Request,
+  context: { params: { raceId: string } }
+) {
+  const { raceId } = context.params;
+
+  try {
+    const data = await getRunRacePrep(raceId);
+
+    if (!data) {
+      return Response.json(
+        { success: false, error: "Race not found" },
+        { status: 404 }
+      );
+    }
+
+    return Response.json({ success: true, data });
+  } catch (error) {
+    console.error("Run race prep error:", error);
+    return Response.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to fetch race prep",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/run/races/route.ts
+++ b/app/api/run/races/route.ts
@@ -1,0 +1,17 @@
+import { listRunRaces } from "@/app/features/run/lib/run-service";
+
+export async function GET() {
+  try {
+    const data = await listRunRaces();
+    return Response.json({ success: true, data });
+  } catch (error) {
+    console.error("Run races error:", error);
+    return Response.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to fetch races",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/features/run/components/ActivityTimeline.tsx
+++ b/app/features/run/components/ActivityTimeline.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/app/components/ui/button";
+import { Text } from "@/app/components/text";
+import type { RunActivity } from "../types";
+import { formatActivityForTimeline } from "../lib/format-activity";
+import { ActivityTimelineItem } from "./ActivityTimelineItem";
+
+interface ActivityTimelineProps {
+  initialActivities: RunActivity[];
+  initialCursor: string | null;
+}
+
+export function ActivityTimeline({
+  initialActivities,
+  initialCursor,
+}: ActivityTimelineProps) {
+  const [activities, setActivities] = useState(initialActivities);
+  const [cursor, setCursor] = useState(initialCursor);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadMore() {
+    if (!cursor || loading) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/run/activities?cursor=${encodeURIComponent(cursor)}&limit=50`
+      );
+      const result = await response.json();
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error ?? "Failed to load activities");
+      }
+
+      setActivities((current) => [...current, ...result.data.activities]);
+      setCursor(result.data.nextCursor);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load activities");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setActivities(initialActivities);
+    setCursor(initialCursor);
+  }, [initialActivities, initialCursor]);
+
+  if (activities.length === 0) {
+    return (
+      <Text className="text-pretty">
+        No activities yet. Connect Strava to sync your running history.
+      </Text>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div>
+        {activities.map((activity) => (
+          <ActivityTimelineItem
+            key={activity.id}
+            activity={formatActivityForTimeline(activity)}
+          />
+        ))}
+      </div>
+
+      {error && <Text className="text-destructive pt-4">{error}</Text>}
+
+      {cursor && (
+        <div className="pt-6">
+          <Button
+            variant="outline"
+            onClick={loadMore}
+            disabled={loading}
+          >
+            {loading ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/features/run/components/ActivityTimelineItem.tsx
+++ b/app/features/run/components/ActivityTimelineItem.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Badge } from "@/app/components/ui/badge";
+import { Text } from "@/app/components/text";
+import type { TimelineActivityView } from "../types";
+
+interface ActivityTimelineItemProps {
+  activity: TimelineActivityView;
+}
+
+export function ActivityTimelineItem({ activity }: ActivityTimelineItemProps) {
+  return (
+    <article className="grid grid-cols-[5.5rem_1fr] sm:grid-cols-[7rem_1fr] gap-x-4 gap-y-1 py-4 border-t border-border first:border-t-0">
+      <time
+        dateTime={activity.dateIso}
+        className="tabular-nums text-muted-foreground pt-0.5"
+      >
+        {activity.dateLabel}
+      </time>
+      <div className="flex flex-col gap-1 min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Text as="span" contrast="high" className="truncate">
+            {activity.name}
+          </Text>
+          <Badge variant="outline">{activity.type}</Badge>
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-1 tabular-nums text-muted-foreground">
+          <span>{activity.distanceLabel}</span>
+          {activity.paceLabel && <span>{activity.paceLabel} /mi</span>}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/app/features/run/components/GoalBlockquote.tsx
+++ b/app/features/run/components/GoalBlockquote.tsx
@@ -1,0 +1,21 @@
+import type { RaceGoal } from "../types";
+import { Text } from "@/app/components/text";
+
+interface GoalBlockquoteProps {
+  goal: RaceGoal;
+}
+
+export function GoalBlockquote({ goal }: GoalBlockquoteProps) {
+  return (
+    <figure className="border-l-2 border-foreground/20 pl-4 py-1">
+      {goal.title && (
+        <Text as="figcaption" contrast="high" weight="medium" className="mb-2">
+          {goal.title}
+        </Text>
+      )}
+      <blockquote>
+        <Text className="text-pretty italic">{goal.description}</Text>
+      </blockquote>
+    </figure>
+  );
+}

--- a/app/features/run/components/RaceBibCard.tsx
+++ b/app/features/run/components/RaceBibCard.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/app/components/ui/card";
+import type { RunRaceSummary } from "../types";
+import { formatDateLong, formatDistance, formatDuration } from "../lib/format";
+
+interface RaceBibCardProps {
+  race: RunRaceSummary;
+}
+
+export function RaceBibCard({ race }: RaceBibCardProps) {
+  return (
+    <Link href={`/run/races/${race.id}`} className="group block h-full">
+      <Card className="h-full transition-colors hover:bg-muted/30 py-5 gap-4">
+        <CardHeader className="px-5 pb-0">
+          <CardDescription className="tabular-nums uppercase tracking-wide text-xs">
+            {formatDateLong(race.date)}
+          </CardDescription>
+          <CardTitle className="text-lg leading-snug">{race.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="px-5 pt-0">
+          <div className="flex flex-wrap gap-x-3 gap-y-1 tabular-nums text-muted-foreground">
+            <span>{race.distanceLabel}</span>
+            {race.finishTimeSeconds != null && (
+              <span>{formatDuration(race.finishTimeSeconds)}</span>
+            )}
+            {race.distanceMeters != null && (
+              <span>{formatDistance(race.distanceMeters)}</span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/app/features/run/components/RaceBibWall.tsx
+++ b/app/features/run/components/RaceBibWall.tsx
@@ -1,0 +1,25 @@
+import type { RunRaceSummary } from "../types";
+import { Text } from "@/app/components/text";
+import { RaceBibCard } from "./RaceBibCard";
+
+interface RaceBibWallProps {
+  races: RunRaceSummary[];
+}
+
+export function RaceBibWall({ races }: RaceBibWallProps) {
+  if (races.length === 0) {
+    return (
+      <Text className="text-pretty">
+        No races configured yet. Add races in your run data config.
+      </Text>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {races.map((race) => (
+        <RaceBibCard key={race.id} race={race} />
+      ))}
+    </div>
+  );
+}

--- a/app/features/run/components/RaceCheckpointChart.tsx
+++ b/app/features/run/components/RaceCheckpointChart.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { RaceCheckpoint } from "../types";
+import { formatDuration, formatPacePerKm } from "../lib/format";
+import { Text } from "@/app/components/text";
+
+interface RaceCheckpointChartProps {
+  checkpoints: RaceCheckpoint[];
+  totalDistanceMeters: number;
+}
+
+export function RaceCheckpointChart({
+  checkpoints,
+  totalDistanceMeters,
+}: RaceCheckpointChartProps) {
+  if (checkpoints.length === 0) {
+    return null;
+  }
+
+  const maxDistance = Math.max(
+    totalDistanceMeters,
+    ...checkpoints.map((checkpoint) => checkpoint.distanceMeters)
+  );
+  const maxElapsed = Math.max(
+    ...checkpoints.map((checkpoint) => checkpoint.elapsedSeconds)
+  );
+
+  const width = 640;
+  const height = 200;
+  const padding = { top: 16, right: 16, bottom: 32, left: 48 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const points = checkpoints.map((checkpoint) => {
+    const x =
+      padding.left +
+      (checkpoint.distanceMeters / maxDistance) * chartWidth;
+    const y =
+      padding.top +
+      chartHeight -
+      (checkpoint.elapsedSeconds / maxElapsed) * chartHeight;
+    return { ...checkpoint, x, y };
+  });
+
+  const polyline = points.map((point) => `${point.x},${point.y}`).join(" ");
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text contrast="high" weight="medium">
+        Race checkpoints
+      </Text>
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          className="w-full min-w-[320px] max-w-2xl text-muted-foreground"
+          role="img"
+          aria-label="Checkpoint pace chart"
+        >
+          <line
+            x1={padding.left}
+            y1={padding.top + chartHeight}
+            x2={padding.left + chartWidth}
+            y2={padding.top + chartHeight}
+            stroke="currentColor"
+            strokeOpacity={0.2}
+          />
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            points={polyline}
+          />
+          {points.map((point) => (
+            <g key={`${point.distanceMeters}-${point.elapsedSeconds}`}>
+              <circle cx={point.x} cy={point.y} r={4} fill="currentColor" />
+              {point.label && (
+                <text
+                  x={point.x}
+                  y={height - 8}
+                  textAnchor="middle"
+                  className="fill-current text-[10px]"
+                >
+                  {point.label}
+                </text>
+              )}
+            </g>
+          ))}
+        </svg>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {checkpoints.map((checkpoint) => (
+          <div
+            key={`${checkpoint.distanceMeters}-${checkpoint.elapsedSeconds}`}
+            className="flex justify-between gap-4 tabular-nums text-sm"
+          >
+            <span className="text-muted-foreground">
+              {checkpoint.label ??
+                `${Math.round(checkpoint.distanceMeters / 1000)}K`}
+            </span>
+            <span>{formatDuration(checkpoint.elapsedSeconds)}</span>
+            <span>{formatPacePerKm(checkpoint.elapsedSeconds, checkpoint.distanceMeters)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/features/run/components/RacePrepTimeline.tsx
+++ b/app/features/run/components/RacePrepTimeline.tsx
@@ -1,0 +1,57 @@
+import { Text } from "@/app/components/text";
+import type { RacePrepActivity } from "../types";
+import {
+  formatDistance,
+  formatDuration,
+  formatPacePerKm,
+  formatShortDate,
+} from "../lib/format";
+
+interface RacePrepTimelineProps {
+  activities: RacePrepActivity[];
+}
+
+export function RacePrepTimeline({ activities }: RacePrepTimelineProps) {
+  if (activities.length === 0) {
+    return (
+      <Text className="text-pretty">
+        No prep activities found in this training window.
+      </Text>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {activities.map((activity) => (
+        <article
+          key={activity.id}
+          className="grid grid-cols-[5.5rem_1fr] sm:grid-cols-[7rem_1fr] gap-x-4 gap-y-1 py-4 border-t border-border first:border-t-0"
+        >
+          <time
+            dateTime={activity.startDate}
+            className="tabular-nums text-muted-foreground pt-0.5"
+          >
+            {formatShortDate(activity.startDate)}
+          </time>
+          <div className="flex flex-col gap-1 min-w-0">
+            <Text as="span" contrast="high" className="truncate">
+              {activity.name}
+            </Text>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 tabular-nums text-muted-foreground">
+              <span>{formatDistance(activity.distanceMeters)}</span>
+              <span>{formatDuration(activity.movingTimeSeconds)}</span>
+              {activity.pacePerKmSeconds != null && (
+                <span>
+                  {formatPacePerKm(
+                    activity.movingTimeSeconds,
+                    activity.distanceMeters
+                  )}
+                </span>
+              )}
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/app/features/run/components/RacePrepView.tsx
+++ b/app/features/run/components/RacePrepView.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import TopOfPage from "@/app/components/topOfPage";
+import { Text } from "@/app/components/text";
+import { GoalBlockquote } from "./GoalBlockquote";
+import { RaceCheckpointChart } from "./RaceCheckpointChart";
+import { RacePrepTimeline } from "./RacePrepTimeline";
+import { SegmentComparisonTable } from "./SegmentComparisonTable";
+import type { RacePrepData } from "../types";
+import {
+  formatDateLong,
+  formatDistance,
+  formatDuration,
+} from "../lib/format";
+
+interface RacePrepViewProps {
+  data: RacePrepData;
+}
+
+export function RacePrepView({ data }: RacePrepViewProps) {
+  const { race, goal, stats, activities, checkpoints, segments } = data;
+
+  return (
+    <div className="flex flex-col gap-10 sm:gap-12 max-w-3xl">
+      <div className="flex flex-col gap-4">
+        <TopOfPage back="/run/races" title={race.name}>
+          <Text>
+            {race.distanceLabel}
+            {race.finishTimeSeconds != null &&
+              ` • ${formatDuration(race.finishTimeSeconds)}`}
+            {` • ${formatDateLong(race.date)}`}
+          </Text>
+        </TopOfPage>
+
+        {goal && <GoalBlockquote goal={goal} />}
+      </div>
+
+      <section className="flex flex-col gap-3">
+        <Text contrast="high" weight="medium">
+          Result
+        </Text>
+        <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 tabular-nums">
+          <div>
+            <dt className="text-muted-foreground">Finish</dt>
+            <dd className="text-foreground">
+              {race.finishTimeSeconds != null
+                ? formatDuration(race.finishTimeSeconds)
+                : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Distance</dt>
+            <dd className="text-foreground">
+              {race.distanceMeters != null
+                ? formatDistance(race.distanceMeters)
+                : race.distanceLabel}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Prep runs</dt>
+            <dd className="text-foreground">{stats.totalActivities}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Prep miles</dt>
+            <dd className="text-foreground">
+              {formatDistance(stats.totalDistanceMeters)}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      {checkpoints.length > 0 && (
+        <RaceCheckpointChart
+          checkpoints={checkpoints}
+          totalDistanceMeters={race.distanceMeters ?? checkpoints.at(-1)?.distanceMeters ?? 0}
+        />
+      )}
+
+      {segments.length > 0 && <SegmentComparisonTable segments={segments} />}
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Text contrast="high" weight="medium">
+            Training block
+          </Text>
+          <Text className="tabular-nums">
+            {formatDateLong(stats.prepStartDate)} – {formatDateLong(stats.prepEndDate)}
+          </Text>
+        </div>
+        <RacePrepTimeline activities={activities} />
+      </section>
+
+      {race.stravaActivityId && (
+        <Link
+          href={`https://www.strava.com/activities/${race.stravaActivityId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground/80 hover:text-foreground underline-offset-4 hover:underline w-fit"
+        >
+          View on Strava
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/app/features/run/components/RunNav.tsx
+++ b/app/features/run/components/RunNav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/app/lib/utils";
+
+const runNavItems = [
+  { href: "/run", label: "Overview", exact: true },
+  { href: "/run/activities", label: "Activities", exact: false },
+  { href: "/run/races", label: "Races", exact: false },
+] as const;
+
+export function RunNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-wrap gap-x-4 gap-y-2">
+      {runNavItems.map((item) => {
+        const isActive = item.exact
+          ? pathname === item.href
+          : pathname.startsWith(item.href);
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "font-medium transition-colors",
+              isActive
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/features/run/components/SegmentComparisonTable.tsx
+++ b/app/features/run/components/SegmentComparisonTable.tsx
@@ -1,0 +1,61 @@
+import type { RaceSegment } from "../types";
+import { formatDuration } from "../lib/format";
+import { Text } from "@/app/components/text";
+
+interface SegmentComparisonTableProps {
+  segments: RaceSegment[];
+}
+
+function formatDiffPercent(best: number, average: number): string {
+  if (average <= 0) return "—";
+  const diff = ((best - average) / average) * 100;
+  const sign = diff <= 0 ? "" : "+";
+  return `${sign}${diff.toFixed(1)}%`;
+}
+
+export function SegmentComparisonTable({
+  segments,
+}: SegmentComparisonTableProps) {
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text contrast="high" weight="medium">
+        Segment comparison
+      </Text>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[420px] text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-muted-foreground">
+              <th className="py-2 pr-4 font-medium">Segment</th>
+              <th className="py-2 pr-4 font-medium">Best lap</th>
+              <th className="py-2 pr-4 font-medium">Avg of 5</th>
+              <th className="py-2 font-medium">Diff</th>
+            </tr>
+          </thead>
+          <tbody>
+            {segments.map((segment) => (
+              <tr key={segment.name} className="border-b border-border/60">
+                <td className="py-2.5 pr-4">{segment.name}</td>
+                <td className="py-2.5 pr-4 tabular-nums">
+                  {formatDuration(segment.bestLapSeconds)}
+                </td>
+                <td className="py-2.5 pr-4 tabular-nums">
+                  {formatDuration(segment.avgOfFiveSeconds)}
+                </td>
+                <td className="py-2.5 tabular-nums">
+                  {formatDiffPercent(
+                    segment.bestLapSeconds,
+                    segment.avgOfFiveSeconds
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/features/run/data/races.ts
+++ b/app/features/run/data/races.ts
@@ -1,0 +1,67 @@
+import type { RaceDefinition } from "../types";
+
+export const raceDefinitions: RaceDefinition[] = [
+  {
+    id: "boston-2024",
+    name: "Boston Marathon",
+    date: "2024-04-15",
+    distanceLabel: "Marathon",
+    distanceMeters: 42195,
+    prepWeeks: 16,
+    goal: {
+      title: "Boston 2024",
+      description:
+        "Run under 2:35 and stay controlled through the Newton hills. Build weekly mileage to 55–60 with a long run peaking at 22 miles.",
+    },
+    checkpoints: [
+      { distanceMeters: 5000, elapsedSeconds: 1080, label: "5K" },
+      { distanceMeters: 10000, elapsedSeconds: 2160, label: "10K" },
+      { distanceMeters: 21097, elapsedSeconds: 4620, label: "Half" },
+      { distanceMeters: 30000, elapsedSeconds: 6480, label: "30K" },
+      { distanceMeters: 42195, elapsedSeconds: 9204, label: "Finish" },
+    ],
+    segments: [
+      { name: "Mile 1", bestLapSeconds: 348, avgOfFiveSeconds: 355 },
+      { name: "Mile 2", bestLapSeconds: 351, avgOfFiveSeconds: 356 },
+      { name: "Mile 3", bestLapSeconds: 354, avgOfFiveSeconds: 358 },
+    ],
+  },
+  {
+    id: "austin-2023",
+    name: "Austin Marathon",
+    date: "2023-02-19",
+    distanceLabel: "Marathon",
+    distanceMeters: 42195,
+    prepWeeks: 14,
+    goal: {
+      description:
+        "First marathon — finish strong and negative split the second half if possible.",
+    },
+    checkpoints: [
+      { distanceMeters: 5000, elapsedSeconds: 1320, label: "5K" },
+      { distanceMeters: 21097, elapsedSeconds: 5580, label: "Half" },
+      { distanceMeters: 42195, elapsedSeconds: 11400, label: "Finish" },
+    ],
+  },
+  {
+    id: "houston-half-2024",
+    name: "Houston Half Marathon",
+    date: "2024-01-14",
+    distanceLabel: "Half Marathon",
+    distanceMeters: 21097,
+    prepWeeks: 10,
+    goal: {
+      description: "Break 1:25 on a flat, fast course.",
+    },
+  },
+];
+
+export function getRaceById(raceId: string): RaceDefinition | undefined {
+  return raceDefinitions.find((race) => race.id === raceId);
+}
+
+export function getAllRaces(): RaceDefinition[] {
+  return [...raceDefinitions].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+}

--- a/app/features/run/lib/config.ts
+++ b/app/features/run/lib/config.ts
@@ -1,0 +1,9 @@
+const DEFAULT_STRAVA_ATHLETE_ID = "13603808";
+
+export function getRunPageAthleteId(): string {
+  return (
+    process.env.STRAVA_ATHLETE_ID ??
+    process.env.RUN_PAGE_USER_ID ??
+    DEFAULT_STRAVA_ATHLETE_ID
+  );
+}

--- a/app/features/run/lib/format-activity.ts
+++ b/app/features/run/lib/format-activity.ts
@@ -1,0 +1,58 @@
+import type { RunActivity, RacePrepActivity, TimelineActivityView } from "../types";
+import {
+  formatDistance,
+  formatDuration,
+  formatPaceFromSpeed,
+  formatShortDate,
+} from "./format";
+
+export function toRunActivity(activity: {
+  id: number;
+  name: string;
+  type: string;
+  start_date_local: string;
+  distance: number;
+  moving_time: number;
+  average_speed: number;
+}): RunActivity {
+  return {
+    id: activity.id,
+    name: activity.name,
+    type: activity.type,
+    startDate: activity.start_date_local,
+    distanceMeters: activity.distance,
+    movingTimeSeconds: activity.moving_time,
+    averageSpeed: activity.average_speed,
+  };
+}
+
+export function formatActivityForTimeline(
+  activity: RunActivity
+): TimelineActivityView {
+  return {
+    id: activity.id,
+    name: activity.name,
+    type: activity.type,
+    dateLabel: formatShortDate(activity.startDate),
+    dateIso: activity.startDate,
+    distanceLabel: formatDistance(activity.distanceMeters),
+    paceLabel: formatPaceFromSpeed(activity.averageSpeed),
+  };
+}
+
+export function mapActivitiesToRacePrep(
+  activities: RunActivity[]
+): RacePrepActivity[] {
+  return activities.map((activity) => ({
+    id: activity.id,
+    name: activity.name,
+    type: activity.type,
+    startDate: activity.startDate,
+    distanceMeters: activity.distanceMeters,
+    movingTimeSeconds: activity.movingTimeSeconds,
+    pacePerKmSeconds:
+      activity.averageSpeed > 0
+        ? Math.round(1000 / activity.averageSpeed)
+        : null,
+  }));
+}

--- a/app/features/run/lib/format.ts
+++ b/app/features/run/lib/format.ts
@@ -1,0 +1,64 @@
+const METERS_TO_MILES = 1609.34;
+const METERS_TO_KM = 1000;
+const SECONDS_PER_MINUTE = 60;
+
+export function formatDistance(meters: number): string {
+  const miles = meters / METERS_TO_MILES;
+  if (miles >= 0.1) {
+    return `${miles.toFixed(1)} mi`;
+  }
+  return `${Math.round(meters)} m`;
+}
+
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / SECONDS_PER_MINUTE);
+  const secs = seconds % SECONDS_PER_MINUTE;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${String(secs).padStart(2, "0")}`;
+}
+
+export function formatPaceFromSpeed(averageSpeedMps: number): string | null {
+  if (!averageSpeedMps || averageSpeedMps <= 0) {
+    return null;
+  }
+
+  const secondsPerMile = METERS_TO_MILES / averageSpeedMps;
+  const minutes = Math.floor(secondsPerMile / SECONDS_PER_MINUTE);
+  const seconds = Math.round(secondsPerMile % SECONDS_PER_MINUTE);
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function formatPacePerKm(
+  elapsedSeconds: number,
+  distanceMeters: number
+): string {
+  if (distanceMeters <= 0) {
+    return "—";
+  }
+
+  const paceSeconds = (elapsedSeconds / distanceMeters) * METERS_TO_KM;
+  const minutes = Math.floor(paceSeconds / SECONDS_PER_MINUTE);
+  const seconds = Math.round(paceSeconds % SECONDS_PER_MINUTE);
+  return `${minutes}:${String(seconds).padStart(2, "0")}/km`;
+}
+
+export function formatShortDate(dateIso: string): string {
+  return new Date(dateIso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatDateLong(dateIso: string): string {
+  return new Date(dateIso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/app/features/run/lib/prep-window.ts
+++ b/app/features/run/lib/prep-window.ts
@@ -1,0 +1,32 @@
+import type { RaceDefinition } from "../types";
+
+const DEFAULT_PREP_WEEKS = 16;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+export interface PrepWindow {
+  startDate: Date;
+  endDate: Date;
+  startIso: string;
+  endIso: string;
+}
+
+export function buildRacePrepWindow(race: RaceDefinition): PrepWindow {
+  const endDate = new Date(`${race.date}T23:59:59`);
+  const prepWeeks = race.prepWeeks ?? DEFAULT_PREP_WEEKS;
+  const startDate = new Date(endDate.getTime() - prepWeeks * MS_PER_WEEK);
+
+  return {
+    startDate,
+    endDate,
+    startIso: startDate.toISOString(),
+    endIso: endDate.toISOString(),
+  };
+}
+
+export function isWithinPrepWindow(
+  activityDateIso: string,
+  window: PrepWindow
+): boolean {
+  const activityDate = new Date(activityDateIso);
+  return activityDate >= window.startDate && activityDate < window.endDate;
+}

--- a/app/features/run/lib/run-service.ts
+++ b/app/features/run/lib/run-service.ts
@@ -1,0 +1,161 @@
+import {
+  fetchAllRunActivities,
+  fetchStravaActivity,
+  getStravaAccessToken,
+  type StravaActivityRaw,
+} from "@/app/features/run/lib/strava";
+import {
+  toRunActivity,
+  mapActivitiesToRacePrep,
+} from "@/app/features/run/lib/format-activity";
+import { buildRacePrepWindow, isWithinPrepWindow } from "@/app/features/run/lib/prep-window";
+import { getRaceById, getAllRaces } from "@/app/features/run/data/races";
+import type {
+  ActivitiesPage,
+  RacePrepData,
+  RunActivity,
+  RunRaceSummary,
+} from "@/app/features/run/types";
+
+function sortActivitiesNewestFirst(activities: RunActivity[]): RunActivity[] {
+  return [...activities].sort(
+    (a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+  );
+}
+
+async function getRunActivities(): Promise<RunActivity[]> {
+  const accessToken = await getStravaAccessToken();
+  if (!accessToken) {
+    return [];
+  }
+
+  const raw = await fetchAllRunActivities(accessToken);
+  return sortActivitiesNewestFirst(raw.map(toRunActivity));
+}
+
+async function resolveRaceSummary(
+  race: ReturnType<typeof getRaceById>,
+  activities: RunActivity[],
+  accessToken: string | null
+): Promise<RunRaceSummary> {
+  if (!race) {
+    throw new Error("Race not found");
+  }
+
+  let finishTimeSeconds: number | null = null;
+  let distanceMeters: number | null = race.distanceMeters ?? null;
+  let stravaActivityId = race.stravaActivityId ?? null;
+
+  if (race.stravaActivityId && accessToken) {
+    const activity = await fetchStravaActivity(accessToken, race.stravaActivityId);
+    if (activity) {
+      finishTimeSeconds = activity.moving_time;
+      distanceMeters = activity.distance;
+      stravaActivityId = activity.id;
+    }
+  } else {
+    const raceDay = race.date;
+    const raceActivity = activities.find((activity) =>
+      activity.startDate.startsWith(raceDay)
+    );
+    if (raceActivity) {
+      finishTimeSeconds = raceActivity.movingTimeSeconds;
+      distanceMeters = raceActivity.distanceMeters;
+      stravaActivityId = raceActivity.id;
+    }
+  }
+
+  return {
+    id: race.id,
+    name: race.name,
+    date: race.date,
+    distanceLabel: race.distanceLabel,
+    distanceMeters,
+    finishTimeSeconds,
+    stravaActivityId,
+  };
+}
+
+export async function listRunActivities(options: {
+  cursor?: string;
+  limit?: number;
+}): Promise<ActivitiesPage> {
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
+  const activities = await getRunActivities();
+
+  let startIndex = 0;
+  if (options.cursor) {
+    const cursorIndex = activities.findIndex(
+      (activity) => activity.startDate === options.cursor
+    );
+    if (cursorIndex >= 0) {
+      startIndex = cursorIndex + 1;
+    }
+  }
+
+  const page = activities.slice(startIndex, startIndex + limit);
+  const nextItem = activities[startIndex + limit];
+
+  return {
+    activities: page,
+    nextCursor: nextItem?.startDate ?? null,
+  };
+}
+
+export async function listRunRaces(): Promise<RunRaceSummary[]> {
+  const accessToken = await getStravaAccessToken();
+  const activities = await getRunActivities();
+  const races = getAllRaces();
+
+  return Promise.all(
+    races.map((race) => resolveRaceSummary(race, activities, accessToken))
+  );
+}
+
+export async function getRunRacePrep(raceId: string): Promise<RacePrepData | null> {
+  const race = getRaceById(raceId);
+  if (!race) {
+    return null;
+  }
+
+  const accessToken = await getStravaAccessToken();
+  const allActivities = await getRunActivities();
+  const raceSummary = await resolveRaceSummary(race, allActivities, accessToken);
+  const window = buildRacePrepWindow(race);
+
+  const prepActivities = allActivities.filter((activity) => {
+    if (raceSummary.stravaActivityId && activity.id === raceSummary.stravaActivityId) {
+      return false;
+    }
+    return isWithinPrepWindow(activity.startDate, window);
+  });
+
+  const mapped = mapActivitiesToRacePrep(prepActivities);
+  const totalDistanceMeters = mapped.reduce(
+    (sum, activity) => sum + activity.distanceMeters,
+    0
+  );
+  const totalMovingTimeSeconds = mapped.reduce(
+    (sum, activity) => sum + activity.movingTimeSeconds,
+    0
+  );
+
+  return {
+    race: raceSummary,
+    goal: race.goal ?? null,
+    stats: {
+      totalActivities: mapped.length,
+      totalDistanceMeters,
+      totalMovingTimeSeconds,
+      prepStartDate: window.startIso,
+      prepEndDate: window.endIso,
+    },
+    activities: mapped.reverse(),
+    checkpoints: race.checkpoints ?? [],
+    segments: race.segments ?? [],
+  };
+}
+
+export function mapStravaActivities(raw: StravaActivityRaw[]): RunActivity[] {
+  return sortActivitiesNewestFirst(raw.map(toRunActivity));
+}

--- a/app/features/run/lib/strava.ts
+++ b/app/features/run/lib/strava.ts
@@ -1,0 +1,184 @@
+import { kv } from "@vercel/kv";
+import { getRunPageAthleteId } from "./config";
+
+export interface StravaActivityRaw {
+  id: number;
+  name: string;
+  type: string;
+  start_date: string;
+  start_date_local: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  average_speed: number;
+}
+
+interface StravaTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+}
+
+export async function getStravaAccessToken(): Promise<string | null> {
+  const athleteId = getRunPageAthleteId();
+  const tokenKey = `strava:token:${athleteId}`;
+
+  try {
+    if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+      const cached = await kv.get<{ accessToken: string; expiresAt: number }>(
+        tokenKey
+      );
+      if (cached && cached.expiresAt > Date.now() / 1000 + 60) {
+        return cached.accessToken;
+      }
+    }
+  } catch (error) {
+    console.error("Token cache read error:", error);
+  }
+
+  if (
+    !process.env.STRAVA_CLIENT_ID ||
+    !process.env.STRAVA_CLIENT_SECRET ||
+    !process.env.STRAVA_REFRESH_TOKEN
+  ) {
+    return null;
+  }
+
+  try {
+    const response = await fetch("https://www.strava.com/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: process.env.STRAVA_CLIENT_ID,
+        client_secret: process.env.STRAVA_CLIENT_SECRET,
+        refresh_token: process.env.STRAVA_REFRESH_TOKEN,
+        grant_type: "refresh_token",
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Token refresh failed: ${response.status}`);
+    }
+
+    const data: StravaTokenResponse = await response.json();
+
+    try {
+      if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+        await kv.set(
+          tokenKey,
+          { accessToken: data.access_token, expiresAt: data.expires_at },
+          { ex: data.expires_at - Math.floor(Date.now() / 1000) }
+        );
+      }
+    } catch (error) {
+      console.error("Token cache write error:", error);
+    }
+
+    return data.access_token;
+  } catch (error) {
+    console.error("Token refresh error:", error);
+    return null;
+  }
+}
+
+export async function fetchAllRunActivities(
+  accessToken: string
+): Promise<StravaActivityRaw[]> {
+  const athleteId = getRunPageAthleteId();
+  const cacheKey = `run:activities:all:${athleteId}`;
+  const cacheTtl = 60 * 60 * 6;
+
+  try {
+    if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+      const cached = await kv.get<StravaActivityRaw[]>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+  } catch (error) {
+    console.error("Activity cache read error:", error);
+  }
+
+  const allActivities: StravaActivityRaw[] = [];
+  let page = 1;
+  const perPage = 200;
+
+  while (true) {
+    const response = await fetch(
+      `https://www.strava.com/api/v3/athlete/activities?page=${page}&per_page=${perPage}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status}`);
+    }
+
+    const activities: StravaActivityRaw[] = await response.json();
+    if (activities.length === 0) break;
+
+    allActivities.push(
+      ...activities.filter((activity) => activity.type === "Run")
+    );
+
+    if (activities.length < perPage) break;
+    page++;
+  }
+
+  try {
+    if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+      await kv.set(cacheKey, allActivities, { ex: cacheTtl });
+    }
+  } catch (error) {
+    console.error("Activity cache write error:", error);
+  }
+
+  return allActivities;
+}
+
+export async function fetchStravaActivity(
+  accessToken: string,
+  activityId: number
+): Promise<StravaActivityRaw | null> {
+  const cacheKey = `run:activity:${activityId}`;
+
+  try {
+    if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+      const cached = await kv.get<StravaActivityRaw>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+  } catch (error) {
+    console.error("Activity cache read error:", error);
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.strava.com/api/v3/activities/${activityId}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const activity: StravaActivityRaw = await response.json();
+
+    try {
+      if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+        await kv.set(cacheKey, activity, { ex: 60 * 60 * 24 });
+      }
+    } catch (error) {
+      console.error("Activity cache write error:", error);
+    }
+
+    return activity;
+  } catch (error) {
+    console.error("Strava activity fetch error:", error);
+    return null;
+  }
+}

--- a/app/features/run/types.ts
+++ b/app/features/run/types.ts
@@ -1,0 +1,91 @@
+export interface RunActivity {
+  id: number;
+  name: string;
+  type: string;
+  startDate: string;
+  distanceMeters: number;
+  movingTimeSeconds: number;
+  averageSpeed: number;
+}
+
+export interface RunRaceSummary {
+  id: string;
+  name: string;
+  date: string;
+  distanceLabel: string;
+  distanceMeters: number | null;
+  finishTimeSeconds: number | null;
+  stravaActivityId: number | null;
+}
+
+export interface RaceCheckpoint {
+  distanceMeters: number;
+  elapsedSeconds: number;
+  label?: string;
+}
+
+export interface RaceSegment {
+  name: string;
+  bestLapSeconds: number;
+  avgOfFiveSeconds: number;
+}
+
+export interface RaceGoal {
+  title?: string;
+  description: string;
+}
+
+export interface RaceDefinition {
+  id: string;
+  name: string;
+  date: string;
+  distanceLabel: string;
+  distanceMeters?: number;
+  stravaActivityId?: number;
+  prepWeeks?: number;
+  goal?: RaceGoal;
+  checkpoints?: RaceCheckpoint[];
+  segments?: RaceSegment[];
+}
+
+export interface RacePrepActivity {
+  id: number;
+  name: string;
+  type: string;
+  startDate: string;
+  distanceMeters: number;
+  movingTimeSeconds: number;
+  pacePerKmSeconds: number | null;
+}
+
+export interface RacePrepStats {
+  totalActivities: number;
+  totalDistanceMeters: number;
+  totalMovingTimeSeconds: number;
+  prepStartDate: string;
+  prepEndDate: string;
+}
+
+export interface RacePrepData {
+  race: RunRaceSummary;
+  goal: RaceGoal | null;
+  stats: RacePrepStats;
+  activities: RacePrepActivity[];
+  checkpoints: RaceCheckpoint[];
+  segments: RaceSegment[];
+}
+
+export interface ActivitiesPage {
+  activities: RunActivity[];
+  nextCursor: string | null;
+}
+
+export interface TimelineActivityView {
+  id: number;
+  name: string;
+  type: string;
+  dateLabel: string;
+  dateIso: string;
+  distanceLabel: string;
+  paceLabel: string | null;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1132,6 +1132,28 @@ export default function Home() {
                 <HomeEnterSection index={6}>
                   <ItemGroup className="gap-0 w-full">
                     <ContactEntry
+                      itemId="contact-run"
+                      href="/run"
+                      title="Run"
+                      trailing="Activities & races"
+                      highlightId={highlightId}
+                      isPreviewActive={
+                        !!previewPanel.panel && highlightId === "contact-run"
+                      }
+                      hideTopDivider={shouldHideListItemTopDivider(
+                        "contact-run",
+                        hoveredListItemId,
+                        `work-${workEntries.length - 1}`
+                      )}
+                      onHover={() =>
+                        handleListItemHover("contact-run", () =>
+                          previewPanel.activateHref("/run")
+                        )
+                      }
+                      onBlur={handleListItemBlur}
+                      onMouseLeave={handleListItemMouseLeave}
+                    />
+                    <ContactEntry
                       itemId="contact-twitter"
                       href="https://twitter.com/austinmrobinson"
                       title="Twitter"
@@ -1143,7 +1165,7 @@ export default function Home() {
                       hideTopDivider={shouldHideListItemTopDivider(
                         "contact-twitter",
                         hoveredListItemId,
-                        `work-${workEntries.length - 1}`
+                        "contact-run"
                       )}
                       onHover={() =>
                         handleListItemHover("contact-twitter", () =>

--- a/app/run/activities/page.tsx
+++ b/app/run/activities/page.tsx
@@ -1,0 +1,27 @@
+import TopOfPage from "@/app/components/topOfPage";
+import { Text } from "@/app/components/text";
+import { listRunActivities } from "@/app/features/run/lib/run-service";
+import { ActivityTimeline } from "@/app/features/run/components/ActivityTimeline";
+
+export const metadata = {
+  title: "Activities",
+};
+
+export default async function RunActivitiesPage() {
+  const { activities, nextCursor } = await listRunActivities({ limit: 50 });
+
+  return (
+    <div className="flex flex-col gap-8 sm:gap-10">
+      <TopOfPage back="/run" title="Activities">
+        <Text className="text-pretty">
+          All-time running activities, newest first.
+        </Text>
+      </TopOfPage>
+
+      <ActivityTimeline
+        initialActivities={activities}
+        initialCursor={nextCursor}
+      />
+    </div>
+  );
+}

--- a/app/run/layout.tsx
+++ b/app/run/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { RunNav } from "@/app/features/run/components/RunNav";
+
+export const metadata: Metadata = {
+  title: "Run",
+  description: "Running activities and race history",
+};
+
+export default function RunLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 sm:gap-10">
+      <RunNav />
+      {children}
+    </div>
+  );
+}

--- a/app/run/page.tsx
+++ b/app/run/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import TopOfPage from "@/app/components/topOfPage";
+import { Text } from "@/app/components/text";
+import { listRunActivities, listRunRaces } from "@/app/features/run/lib/run-service";
+import { ActivityTimeline } from "@/app/features/run/components/ActivityTimeline";
+import { RaceBibWall } from "@/app/features/run/components/RaceBibWall";
+import { formatDistance } from "@/app/features/run/lib/format";
+
+export default async function RunPage() {
+  const [{ activities, nextCursor }, races] = await Promise.all([
+    listRunActivities({ limit: 10 }),
+    listRunRaces(),
+  ]);
+
+  const totalDistanceMeters = activities.reduce(
+    (sum, activity) => sum + activity.distanceMeters,
+    0
+  );
+
+  return (
+    <div className="flex flex-col gap-10 sm:gap-12">
+      <TopOfPage title="Run">
+        <Text className="text-pretty">
+          All-time activities and race prep — a running log inspired by the
+          simplicity of a lifetime timeline and a bib wall of races.
+        </Text>
+      </TopOfPage>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <Text contrast="high" weight="medium">
+              Recent activities
+            </Text>
+            {activities.length > 0 && (
+              <Text className="tabular-nums">
+                {activities.length} loaded
+                {totalDistanceMeters > 0 &&
+                  ` • ${formatDistance(totalDistanceMeters)}`}
+              </Text>
+            )}
+          </div>
+          <Link
+            href="/run/activities"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View all
+          </Link>
+        </div>
+        <ActivityTimeline
+          initialActivities={activities}
+          initialCursor={nextCursor}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-end justify-between gap-4">
+          <Text contrast="high" weight="medium">
+            Races
+          </Text>
+          <Link
+            href="/run/races"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Bib wall
+          </Link>
+        </div>
+        <RaceBibWall races={races.slice(0, 3)} />
+      </section>
+    </div>
+  );
+}

--- a/app/run/races/[raceId]/not-found.tsx
+++ b/app/run/races/[raceId]/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import TopOfPage from "@/app/components/topOfPage";
+import { Text } from "@/app/components/text";
+
+export default function RunRaceNotFound() {
+  return (
+    <div className="flex flex-col gap-4">
+      <TopOfPage back="/run/races" title="Race not found">
+        <Text>This race is not in your bib wall.</Text>
+      </TopOfPage>
+      <Link
+        href="/run/races"
+        className="text-foreground/80 hover:text-foreground underline-offset-4 hover:underline w-fit"
+      >
+        Back to races
+      </Link>
+    </div>
+  );
+}

--- a/app/run/races/[raceId]/page.tsx
+++ b/app/run/races/[raceId]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+import { getRunRacePrep } from "@/app/features/run/lib/run-service";
+import { RacePrepView } from "@/app/features/run/components/RacePrepView";
+
+interface RaceDetailPageProps {
+  params: { raceId: string };
+}
+
+export async function generateMetadata({ params }: RaceDetailPageProps) {
+  const data = await getRunRacePrep(params.raceId);
+
+  if (!data) {
+    return { title: "Race not found" };
+  }
+
+  return {
+    title: data.race.name,
+    description: `${data.race.distanceLabel} on ${data.race.date}`,
+  };
+}
+
+export default async function RaceDetailPage({ params }: RaceDetailPageProps) {
+  const data = await getRunRacePrep(params.raceId);
+
+  if (!data) {
+    notFound();
+  }
+
+  return <RacePrepView data={data} />;
+}

--- a/app/run/races/page.tsx
+++ b/app/run/races/page.tsx
@@ -1,0 +1,25 @@
+import TopOfPage from "@/app/components/topOfPage";
+import { Text } from "@/app/components/text";
+import { listRunRaces } from "@/app/features/run/lib/run-service";
+import { RaceBibWall } from "@/app/features/run/components/RaceBibWall";
+
+export const metadata = {
+  title: "Races",
+};
+
+export default async function RunRacesPage() {
+  const races = await listRunRaces();
+
+  return (
+    <div className="flex flex-col gap-8 sm:gap-10">
+      <TopOfPage back="/run" title="Races">
+        <Text className="text-pretty">
+          A bib wall of races. Select a race to see the training block leading
+          up to it.
+        </Text>
+      </TopOfPage>
+
+      <RaceBibWall races={races} />
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a single-owner public `/run` section inspired by [rauno.me/run](https://rauno.me/run) and [kyles.run](https://www.kyles.run/):

- **Activities timeline** — all-time Strava runs, newest first, with cursor pagination
- **Race bib wall** — grid of configured races with finish stats
- **Race prep detail** — training block timeline, goal quote, checkpoint chart, and segment comparison per race

## Architecture

Adapted to this repo's App Router + REST API stack (no tRPC/DB):

- Strava sync via `/api/run/*` with KV caching
- Single owner resolved from `STRAVA_ATHLETE_ID` / `RUN_PAGE_USER_ID`
- Race metadata, goals, checkpoints, and segments in `app/features/run/data/races.ts`

## Routes

| Route | Purpose |
|-------|---------|
| `/run` | Overview with recent activities + races preview |
| `/run/activities` | Full all-time timeline |
| `/run/races` | Bib wall |
| `/run/races/[raceId]` | Race result + prep drill-down |

## Setup

Add Strava credentials to `.env.local` (see `.env.example`). Update `app/features/run/data/races.ts` with your actual races and optional `stravaActivityId` for each.

## Homepage

Adds a **Run** link under Contact pointing to `/run`.

## Test plan

- [ ] Set Strava env vars and verify `/run/activities` loads synced runs
- [ ] Confirm bib wall renders configured races
- [ ] Click a race and verify prep timeline + goal/checkpoint/segment sections
- [ ] Test "Load more" pagination on activities page
- [ ] Verify build passes (`pnpm build`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af38c6f7-45f1-452b-88f0-70bd266fda7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af38c6f7-45f1-452b-88f0-70bd266fda7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

